### PR TITLE
fixed typo in the `mem` command

### DIFF
--- a/src/misc_commands.p8
+++ b/src/misc_commands.p8
@@ -60,7 +60,7 @@ misc_commands {
         txt.print_uw(cx16.numbanks())
         txt.chrout(iso:'=')
         txt.print_uw(cx16.numbanks() * $0008)
-        txt.print(iso:"Kb\rMemTop: ")
+        txt.print(iso:"KB\rMemTop: ")
         txt.print_uwhex(cbm.MEMTOP(0, true), true)
         txt.nl()
         return true


### PR DESCRIPTION
`mem` command abreviated KiloBytes as "Kb", which isn't good, because that's how we write Kilo*bit*s