### PR TITLE
Draft: neofetch boot configurable by motd.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 *.asm
 *.vice-mon-list
 SHELL-CMDS
+
 # for local batch scripts used by windows contributors
 compile.bat

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 *.prg
 *.asm
 *.vice-mon-list
+SHELL-CMDS
+# for local batch scripts used by windows contributors
+compile.bat

--- a/src/shell.p8
+++ b/src/shell.p8
@@ -192,8 +192,15 @@ main {
         txt.clear_screen()
 
         if diskio.f_open(misc_commands.motd_file) {
+            str temp="?"*32
+            diskio.f_readline(temp)
             diskio.f_close()
-            void misc_commands.cmd_motd()
+            if temp=="#!neofetch" and diskio.load(petscii:"//shell-cmds/:neofetch", 0){
+                void run_external_command()
+            }
+            else{
+                void misc_commands.cmd_motd()
+            }
         } else {
             diskio.send_command(petscii:"i")
         }

--- a/src/shell.p8
+++ b/src/shell.p8
@@ -195,7 +195,7 @@ main {
             str temp="?"*32
             diskio.f_readline(temp)
             diskio.f_close()
-            if temp=="#!neofetch" and diskio.load(petscii:"//shell-cmds/:neofetch", 0){
+            if (temp=="#!neofetch" or temp==petscii:"#!neofetch") and diskio.load(petscii:"//shell-cmds/:neofetch", 0){
                 void run_external_command()
             }
             else{


### PR DESCRIPTION
This pull request adds a functionality to startup routine, that executes neofetch external command in case the first line of motd.txt is equal to `#!neofetch`

This functionality could potentially be expanded to allow auto-starting any kind of command and other things. 